### PR TITLE
add pwa implementation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ const monaSans = Mona_Sans({
 });
 
 export const metadata: Metadata = {
+  manifest: "/manifest.json",
   title: "Interviewly",
   description: "An AI-powered platform for preparing for mock interviews",
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import withPWA from "next-pwa";
 
 
 const nextConfig: NextConfig = {
@@ -10,4 +11,12 @@ const nextConfig: NextConfig = {
   }
 };
 
-export default nextConfig;
+const pwaConfig = {
+  dest: "public",
+  register: true,
+  skipWaiting: true,
+  disable: false,
+  reloadOnOnline: true
+}
+
+export default withPWA(pwaConfig)(nextConfig as any);

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+    "name": "Interviewly",
+    "short_name": "Interviewly",
+    "description": "AI-powered interview practice platform",
+    "start_url": "/",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#cac5fe",
+    "icons": [
+      {
+        "src": "/logo192.png",
+        "sizes": "192x192",
+        "type": "image/png"
+      },
+      {
+        "src": "/logo512.png",
+        "sizes": "512x512",
+        "type": "image/png"
+      }
+    ]
+  }


### PR DESCRIPTION
This pull request introduces Progressive Web App (PWA) support to the project by integrating the `next-pwa` library, adding a `manifest.json` file, and updating the configuration. These changes enable the application to function as a PWA, improving offline capabilities and user experience on mobile devices.

### PWA Integration:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR2): Added the `next-pwa` library and configured it with options such as `dest`, `register`, `skipWaiting`, and `reloadOnOnline`. Updated the export to wrap the `nextConfig` with `withPWA`. [[1]](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR2) [[2]](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bL13-R22)

* [`public/manifest.json`](diffhunk://#diff-639916bc14c3f311c31f629a2ec116292a4b2f64d06b3607b9ddd2e495703895R1-R21): Introduced a new `manifest.json` file defining PWA metadata, including `name`, `short_name`, `start_url`, `icons`, and theme-related properties.

* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR12): Added a reference to the `manifest.json` file in the `metadata` object to ensure proper linking.

 
### Screenshots
## Install APP
![image](https://github.com/user-attachments/assets/268319c0-3ced-4f29-ada5-a2b0fa54fd5b)

## Native APP
![image](https://github.com/user-attachments/assets/3721ae98-d9b6-49bf-a7ff-ed588ec7521a)
